### PR TITLE
Add quotation syntax sugar

### DIFF
--- a/Blang.Tests/Blang.Tests.fsproj
+++ b/Blang.Tests/Blang.Tests.fsproj
@@ -2,13 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ValueTests.fs" />
     <Compile Include="LexerTests.fs" />
     <Compile Include="ParserTests.fs" />
-    <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="2.14.3" />

--- a/Blang.Tests/Program.fs
+++ b/Blang.Tests/Program.fs
@@ -1,1 +1,0 @@
-module Program = let [<EntryPoint>] main _ = 0

--- a/Blang/ParserTypes.fs
+++ b/Blang/ParserTypes.fs
@@ -4,7 +4,9 @@ type TokenType =
     | Number of double
     | String of string
     | Symbol of string
+    | QuotedSymbol of string
     | LParen
+    | QuotedLParen
     | RParen
     | EOF
 


### PR DESCRIPTION
Closes #20 

`'(__expression__)` desugars to `(' (__expression__))`
`'symbol` desugars `(' symbol)`

Not implemented for strings or numbers since there's no need to quote those value types.